### PR TITLE
fix: change container port to 80 in nginx-app.yaml

### DIFF
--- a/deployment/nginx-app.yaml
+++ b/deployment/nginx-app.yaml
@@ -18,4 +18,4 @@ spec:
       - name: nginx-app
         image: nginx
         ports:
-        - containerPort: 8080
+        - containerPort: 80


### PR DESCRIPTION
### Related issue

 #2 

### Working for this issue

- f622c24a4426c305645002b589c88b7912f8a914
  - [fix: change container port to 80 in nginx-app.yaml](https://github.com/arisu1000/kubernetes-book-sample/commit/f622c24a4426c305645002b589c88b7912f8a914)
    - in the official nginx image, default server listening port is 80
    - but container port of the nginx-app.yaml is 8080 so container was made by this yaml can not response for the user's request.
    - for this issue, I changed container port to 80 which same with nginx server default listening port.